### PR TITLE
Repo api 9678 dev

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -2181,6 +2181,27 @@ class _BlitzGateway (object):
         """
         return ProxyObjectWrapper(self, 'createExporter')
 
+    def lookupRepository (self, klass):
+        """
+        Returns reference to the first ManagedRepository.
+
+        @param klass:     The Repository class name
+        @type klass:      String
+
+        @return:    omero.grid.ManagedRepositoryPrx
+        """
+        klass = '%sPrx' % klass
+        klass = getattr(omero.grid, klass)
+        repos = self.getSharedResources().repositories().proxies
+        for proxy in repos:
+            if proxy is not None:
+                repository = omero.grid.ManagedRepositoryPrx.checkedCast(proxy)
+                if repository is not None:
+                    description = repository.root()
+                    return (repository, description)
+        raise AttributError('Repository of type %s unavailable' % klass)
+
+
     #############################
     # Top level object fetchers #
 

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -2197,8 +2197,7 @@ class _BlitzGateway (object):
             if proxy is not None:
                 repository = omero.grid.ManagedRepositoryPrx.checkedCast(proxy)
                 if repository is not None:
-                    description = repository.root()
-                    return (repository, description)
+                    return repository
         raise AttributError('Repository of type %s unavailable' % klass)
 
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1715,8 +1715,8 @@ def repository(request, klass, conn=None, **kwargs):
     """
     Returns a repository and its root property
     """
-    repository, description = get_repository(conn, klass)
-    return dict(repository=OriginalFileWrapper(conn=conn, obj=description).simpleMarshal(),
+    repository = get_repository(conn, klass)
+    return dict(repository=OriginalFileWrapper(conn=conn, obj=repository.root()).simpleMarshal(),
                 root=unwrap(repository.root().path))
 
 
@@ -1728,8 +1728,8 @@ def repository_list(request, klass, filepath=None, conn=None, **kwargs):
     returns files at the top level of the repository, otherwise files within
     the specified filepath
     """
-    repository, description = get_repository(conn, klass)
-    name = OriginalFileWrapper(conn=conn, obj=description).getName()
+    repository = get_repository(conn, klass)
+    name = unwrap(repository.root().name)
     root = os.path.join(unwrap(repository.root().path), name)
     if filepath:
         root = os.path.join(root, filepath)
@@ -1748,8 +1748,8 @@ def repository_listfiles(request, klass, filepath=None, conn=None, **kwargs):
     If filepath is not specified, returns files at the top level of the
     repository, otherwise files within the specified filepath
     """
-    repository, description = get_repository(conn, klass)
-    name = OriginalFileWrapper(conn=conn, obj=description).getName()
+    repository = get_repository(conn, klass)
+    name = unwrap(repository.root().name)
     root = os.path.join(unwrap(repository.root().path), name)
     if filepath:
         root = os.path.join(root, filepath)
@@ -1772,8 +1772,8 @@ def repository_sha(request, klass, filepath, conn=None, **kwargs):
     """
     json method: Returns the sha1 checksum of the specified file
     """
-    repository, description = get_repository(conn, klass)
-    name = OriginalFileWrapper(conn=conn, obj=description).getName()
+    repository = get_repository(conn, klass)
+    name = unwrap(repository.root().name)
     fullpath = os.path.join(unwrap(repository.root().path), name, filepath)
 
     try:
@@ -1795,9 +1795,9 @@ def repository_root(request, klass, conn=None, **kwargs):
     """
     Returns the root and name property of a repository
     """
-    repository, description = get_repository(conn, klass)
+    repository = get_repository(conn, klass)
     return dict(root=unwrap(repository.root().path),
-                name=OriginalFileWrapper(conn=conn, obj=description).getName())
+                name=unwrap(repository.root().name))
 
 
 @require_POST
@@ -1807,9 +1807,9 @@ def repository_makedir(request, klass, dirpath, conn=None, **kwargs):
     """
     Creates a directory in a repository
     """
-    repository, description = get_repository(conn, klass)
+    repository = get_repository(conn, klass)
     root = unwrap(repository.root().path)
-    name = OriginalFileWrapper(conn=conn, obj=description).getName()
+    name = unwrap(repository.root().name)
 
     try:
         path = os.path.join(root, name, dirpath)
@@ -1843,8 +1843,8 @@ def repository_download(request, klass, filepath, conn=None, **kwargs):
     Downloads a file from a repository.  Supports the HTTP_RANGE header to
     perform partial downloads or download continuation
     """
-    repository, description = get_repository(conn, klass)
-    name = OriginalFileWrapper(conn=conn, obj=description).getName()
+    repository = get_repository(conn, klass)
+    name = unwrap(repository.root().name)
     fullpath = os.path.join(unwrap(repository.root().path), name, filepath)
 
     try:
@@ -1959,8 +1959,8 @@ def process_request(require_uploadId):
         @uncloak_self
         def decorated(self, request, klass, filepath, conn, **kwargs):
 
-            repository, description = get_repository(conn, klass)
-            name = OriginalFileWrapper(conn=conn, obj=description).getName()
+            repository = get_repository(conn, klass)
+            name = unwrap(repository.root().name)
             fullpath = os.path.join(unwrap(repository.root().path), name, filepath)
 
             objectname = os.path.basename(fullpath)

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1692,16 +1692,7 @@ def su (request, user, conn=None, **kwargs):
     return True
 
 def get_repository(conn, klass):
-    klass = '%sPrx' % klass
-    klass = getattr(omero.grid, klass)
-    sr = conn.getSharedResources()
-    repositories = sr.repositories()
-    for index, proxy in enumerate(repositories.proxies):
-        repository = klass.checkedCast(proxy)
-        if repository is not None:
-            description = repositories.descriptions[index]
-            return (repository, description)
-    raise AttributError('Repository of type %s unavailable' % klass)
+    return conn.lookupRepository(klass)
 
 @login_required()
 @jsonp

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1691,9 +1691,6 @@ def su (request, user, conn=None, **kwargs):
     conn.seppuku()
     return True
 
-def get_repository(conn, klass):
-    return conn.lookupRepository(klass)
-
 @login_required()
 @jsonp
 def repositories(request, conn=None, **kwargs):
@@ -1715,7 +1712,7 @@ def repository(request, klass, conn=None, **kwargs):
     """
     Returns a repository and its root property
     """
-    repository = get_repository(conn, klass)
+    repository = conn.lookupRepository(klass)
     return dict(repository=OriginalFileWrapper(conn=conn, obj=repository.root()).simpleMarshal(),
                 root=unwrap(repository.root().path))
 
@@ -1728,7 +1725,7 @@ def repository_list(request, klass, filepath=None, conn=None, **kwargs):
     returns files at the top level of the repository, otherwise files within
     the specified filepath
     """
-    repository = get_repository(conn, klass)
+    repository = conn.lookupRepository(klass)
     name = unwrap(repository.root().name)
     root = os.path.join(unwrap(repository.root().path), name)
     if filepath:
@@ -1748,7 +1745,7 @@ def repository_listfiles(request, klass, filepath=None, conn=None, **kwargs):
     If filepath is not specified, returns files at the top level of the
     repository, otherwise files within the specified filepath
     """
-    repository = get_repository(conn, klass)
+    repository = conn.lookupRepository(klass)
     name = unwrap(repository.root().name)
     root = os.path.join(unwrap(repository.root().path), name)
     if filepath:
@@ -1772,7 +1769,7 @@ def repository_sha(request, klass, filepath, conn=None, **kwargs):
     """
     json method: Returns the sha1 checksum of the specified file
     """
-    repository = get_repository(conn, klass)
+    repository = conn.lookupRepository(klass)
     name = unwrap(repository.root().name)
     fullpath = os.path.join(unwrap(repository.root().path), name, filepath)
 
@@ -1795,7 +1792,7 @@ def repository_root(request, klass, conn=None, **kwargs):
     """
     Returns the root and name property of a repository
     """
-    repository = get_repository(conn, klass)
+    repository = conn.lookupRepository(klass)
     return dict(root=unwrap(repository.root().path),
                 name=unwrap(repository.root().name))
 
@@ -1807,7 +1804,7 @@ def repository_makedir(request, klass, dirpath, conn=None, **kwargs):
     """
     Creates a directory in a repository
     """
-    repository = get_repository(conn, klass)
+    repository = conn.lookupRepository(klass)
     root = unwrap(repository.root().path)
     name = unwrap(repository.root().name)
 
@@ -1843,7 +1840,7 @@ def repository_download(request, klass, filepath, conn=None, **kwargs):
     Downloads a file from a repository.  Supports the HTTP_RANGE header to
     perform partial downloads or download continuation
     """
-    repository = get_repository(conn, klass)
+    repository = conn.lookupRepository(klass)
     name = unwrap(repository.root().name)
     fullpath = os.path.join(unwrap(repository.root().path), name, filepath)
 
@@ -1959,7 +1956,7 @@ def process_request(require_uploadId):
         @uncloak_self
         def decorated(self, request, klass, filepath, conn, **kwargs):
 
-            repository = get_repository(conn, klass)
+            repository = conn.lookupRepository(klass)
             name = unwrap(repository.root().name)
             fullpath = os.path.join(unwrap(repository.root().path), name, filepath)
 


### PR DESCRIPTION
Opening a PR on this so that I can get some feedback. 

This branch pushes the repository lookup to the Blitz gateway but maintains using the repository class name as an argument. It drops the description as a return value as it isn't needed. views.py is then refactored to use this method.
